### PR TITLE
Improved Comment Deletion & Fixed Flag Bug

### DIFF
--- a/public/js/build.js
+++ b/public/js/build.js
@@ -309,34 +309,37 @@ document.addEventListener("DOMContentLoaded", function() {
   }
 
   // Comments - Flag Comment
-  if(idExists('linkFlagComment')) {
-    document.getElementById('linkFlagComment').addEventListener('click', function(e){
-      e.preventDefault();
-      var targetCommentID = this.dataset.commentid;
-      var flagger = this.dataset.flagger;
-      var flagConf = confirm('Are you sure you want to flag this comment as abuse / spam / in violation of the community guidelines?');
-      if (flagConf) {
-        aja()
-        .method('post')
-        .url('/api/comments/flag')
-        .body({ flagger: flagger, id: targetCommentID })
-        .cache(false)
-        .on('200', function(response){
-          // Reload the window to show the comment has been removed
-          window.location.reload();
-        })
-         .on('40x', function(response){
-            //something is definitely wrong
-            // 'x' means any number (404, 400, etc. will match)
-            console.log(response);
-        })
-        .on('500', function(response){
-            //oh crap
-            console.log(response);
-        })
-        .go();
-      }
-    });
+  if(classExists('link-flag-comment')) {
+    var flagLinks = document.getElementsByClassName('link-flag-comment');
+    for (var i = 0; i < flagLinks.length; i++) {
+      flagLinks[i].addEventListener('click', function(e){
+        e.preventDefault();
+        var targetCommentID = this.dataset.commentid;
+        var flagger = this.dataset.flagger;
+        var flagConf = confirm('Are you sure you want to flag this comment as abuse / spam / in violation of the community guidelines?');
+        if (flagConf) {
+          aja()
+          .method('post')
+          .url('/api/comments/flag')
+          .body({ flagger: flagger, id: targetCommentID })
+          .cache(false)
+          .on('200', function(response){
+            // Reload the window to show the comment has been removed
+            window.location.reload();
+          })
+           .on('40x', function(response){
+              //something is definitely wrong
+              // 'x' means any number (404, 400, etc. will match)
+              console.log(response);
+          })
+          .on('500', function(response){
+              //oh crap
+              console.log(response);
+          })
+          .go();
+        }
+      });
+    }
   }
 
 

--- a/public/js/build.js
+++ b/public/js/build.js
@@ -274,33 +274,38 @@ document.addEventListener("DOMContentLoaded", function() {
   }
 
   // Comments - Delete Comment
-  if(idExists('linkDeleteComment')) {
-    document.getElementById('linkDeleteComment').addEventListener('click', function(e){
-      e.preventDefault();
-      var targetCommentID = this.dataset.commentid;
-      var deleteConf = confirm('Are you sure you want to delete this comment?');
-      // Ajax delete the comment
-      if(deleteConf) {
-        aja()
-        .method('get')
-        .url('/api/comments/' + targetCommentID + '/remove')
-        .cache(false)
-        .on('200', function(response){
-          // Reload the window to show the comment has been removed
-          window.location.reload();
-        })
-         .on('40x', function(response){
-            //something is definitely wrong
-            // 'x' means any number (404, 400, etc. will match)
-            console.log(response);
-        })
-        .on('500', function(response){
-            //oh crap
-            console.log(response);
-        })
-        .go();
-      }
-    });
+  if(classExists('link-delete-comment')) {
+    var deleteLinks = document.getElementsByClassName('link-delete-comment');
+    for (var i = 0; i < deleteLinks.length; i++) {
+      deleteLinks[i].addEventListener('click', function(e) {
+        e.preventDefault();
+        var targetCommentID = this.dataset.commentid;
+        var userID = this.dataset.userid;
+        var deleteConf = confirm('Are you sure you want to delete this comment?');
+        // Ajax delete the comment
+        if(deleteConf) {
+          aja()
+          .method('post')
+          .url('/api/comments/' + targetCommentID + '/remove')
+          .data({ userID: userID })
+          .cache(false)
+          .on('200', function(response){
+            // Reload the window to show the comment has been removed
+            window.location.reload();
+          })
+           .on('40x', function(response){
+              //something is definitely wrong
+              // 'x' means any number (404, 400, etc. will match)
+              console.log(response);
+          })
+          .on('500', function(response){
+              //oh crap
+              console.log(response);
+          })
+          .go();
+        }
+      });
+    }
   }
 
   // Comments - Flag Comment
@@ -348,6 +353,13 @@ document.addEventListener("DOMContentLoaded", function() {
 
   function idExists(el) {
     if (document.getElementById(el)) {
+      return true;
+    }
+    return false;
+  }
+
+  function classExists(className) {
+    if (document.getElementsByClassName(className).length > 0) {
       return true;
     }
     return false;

--- a/routes/api/comments.js
+++ b/routes/api/comments.js
@@ -4,6 +4,7 @@ var nodemailer = require('nodemailer');
 var cbOptions = require('../../options.js');
 
 var Comment = keystone.list('Comment');
+var User = keystone.list('User');
 
 /**
  * List Comments
@@ -76,6 +77,15 @@ exports.update = function(req, res) {
  * Delete Comment by ID
  */
 exports.remove = function(req, res) {
+
+  // Make sure the user requesting the delete is an admin
+  User.model.findById(req.body.userID).exec(function (err, user) {
+    if (err) { return res.apiError('database error', err) };
+    if (!user) {
+      return res.apiResponse({ success: false });
+    }
+  });
+
   Comment.model.findById(req.params.id).exec(function (err, item) {
     if (err) { return res.apiError('database error', err) };
     if (!item) { return res.apiError('not found') };

--- a/routes/index.js
+++ b/routes/index.js
@@ -77,7 +77,7 @@ exports = module.exports = function (app) {
   app.all('/api/comments/create', keystone.middleware.api, routes.api.comments.create);
   app.get('/api/comments/:id', keystone.middleware.api, routes.api.comments.get);
   app.all('/api/comments/:id/update', keystone.middleware.api, routes.api.comments.update);
-  app.get('/api/comments/:id/remove', keystone.middleware.api, routes.api.comments.remove);
+  app.all('/api/comments/:id/remove', keystone.middleware.api, routes.api.comments.remove);
   app.all('/api/comments/flag', keystone.middleware.api, routes.api.comments.flag);
 
 	// NOTE: To protect a route so that only admins can see it, use the requireUser middleware:

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -201,33 +201,38 @@ document.addEventListener("DOMContentLoaded", function() {
   }
 
   // Comments - Delete Comment
-  if(idExists('linkDeleteComment')) {
-    document.getElementById('linkDeleteComment').addEventListener('click', function(e){
-      e.preventDefault();
-      var targetCommentID = this.dataset.commentid;
-      var deleteConf = confirm('Are you sure you want to delete this comment?');
-      // Ajax delete the comment
-      if(deleteConf) {
-        aja()
-        .method('get')
-        .url('/api/comments/' + targetCommentID + '/remove')
-        .cache(false)
-        .on('200', function(response){
-          // Reload the window to show the comment has been removed
-          window.location.reload();
-        })
-         .on('40x', function(response){
-            //something is definitely wrong
-            // 'x' means any number (404, 400, etc. will match)
-            console.log(response);
-        })
-        .on('500', function(response){
-            //oh crap
-            console.log(response);
-        })
-        .go();
-      }
-    });
+  if(classExists('link-delete-comment')) {
+    var deleteLinks = document.getElementsByClassName('link-delete-comment');
+    for (var i = 0; i < deleteLinks.length; i++) {
+      deleteLinks[i].addEventListener('click', function(e) {
+        e.preventDefault();
+        var targetCommentID = this.dataset.commentid;
+        var userID = this.dataset.userid;
+        var deleteConf = confirm('Are you sure you want to delete this comment?');
+        // Ajax delete the comment
+        if(deleteConf) {
+          aja()
+          .method('post')
+          .url('/api/comments/' + targetCommentID + '/remove')
+          .data({ userID: userID })
+          .cache(false)
+          .on('200', function(response){
+            // Reload the window to show the comment has been removed
+            window.location.reload();
+          })
+           .on('40x', function(response){
+              //something is definitely wrong
+              // 'x' means any number (404, 400, etc. will match)
+              console.log(response);
+          })
+          .on('500', function(response){
+              //oh crap
+              console.log(response);
+          })
+          .go();
+        }
+      });
+    }
   }
 
   // Comments - Flag Comment
@@ -275,6 +280,13 @@ document.addEventListener("DOMContentLoaded", function() {
 
   function idExists(el) {
     if (document.getElementById(el)) {
+      return true;
+    }
+    return false;
+  }
+
+  function classExists(className) {
+    if (document.getElementsByClassName(className).length > 0) {
       return true;
     }
     return false;

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -236,34 +236,37 @@ document.addEventListener("DOMContentLoaded", function() {
   }
 
   // Comments - Flag Comment
-  if(idExists('linkFlagComment')) {
-    document.getElementById('linkFlagComment').addEventListener('click', function(e){
-      e.preventDefault();
-      var targetCommentID = this.dataset.commentid;
-      var flagger = this.dataset.flagger;
-      var flagConf = confirm('Are you sure you want to flag this comment as abuse / spam / in violation of the community guidelines?');
-      if (flagConf) {
-        aja()
-        .method('post')
-        .url('/api/comments/flag')
-        .body({ flagger: flagger, id: targetCommentID })
-        .cache(false)
-        .on('200', function(response){
-          // Reload the window to show the comment has been removed
-          window.location.reload();
-        })
-         .on('40x', function(response){
-            //something is definitely wrong
-            // 'x' means any number (404, 400, etc. will match)
-            console.log(response);
-        })
-        .on('500', function(response){
-            //oh crap
-            console.log(response);
-        })
-        .go();
-      }
-    });
+  if(classExists('link-flag-comment')) {
+    var flagLinks = document.getElementsByClassName('link-flag-comment');
+    for (var i = 0; i < flagLinks.length; i++) {
+      flagLinks[i].addEventListener('click', function(e){
+        e.preventDefault();
+        var targetCommentID = this.dataset.commentid;
+        var flagger = this.dataset.flagger;
+        var flagConf = confirm('Are you sure you want to flag this comment as abuse / spam / in violation of the community guidelines?');
+        if (flagConf) {
+          aja()
+          .method('post')
+          .url('/api/comments/flag')
+          .body({ flagger: flagger, id: targetCommentID })
+          .cache(false)
+          .on('200', function(response){
+            // Reload the window to show the comment has been removed
+            window.location.reload();
+          })
+           .on('40x', function(response){
+              //something is definitely wrong
+              // 'x' means any number (404, 400, etc. will match)
+              console.log(response);
+          })
+          .on('500', function(response){
+              //oh crap
+              console.log(response);
+          })
+          .go();
+        }
+      });
+    }
   }
 
 

--- a/templates/views/partials/comments.hbs
+++ b/templates/views/partials/comments.hbs
@@ -68,7 +68,7 @@
                   <div class="links">
                     {{#ifeq ../user.id this.author.id}}
                     {{else}}
-                      <a href="#" id="linkFlagComment" class="flag" data-flagger="{{../user.id}}" data-commentID="{{this.id}}">Flag</a> |
+                      <a href="#" class="flag link-flag-comment" data-flagger="{{../user.id}}" data-commentID="{{this.id}}">Flag</a> |
                     {{/ifeq}}
                     {{#if ../user.isAdmin}}
                       <a href="#" class="link-delete-comment" data-commentID="{{this.id}}" data-userID="{{../user.id}}">Delete</a> |

--- a/templates/views/partials/comments.hbs
+++ b/templates/views/partials/comments.hbs
@@ -71,7 +71,7 @@
                       <a href="#" id="linkFlagComment" class="flag" data-flagger="{{../user.id}}" data-commentID="{{this.id}}">Flag</a> |
                     {{/ifeq}}
                     {{#if ../user.isAdmin}}
-                      <a href="#" id="linkDeleteComment" data-commentID="{{this.id}}">Delete</a> |
+                      <a href="#" class="link-delete-comment" data-commentID="{{this.id}}" data-userID="{{../user.id}}">Delete</a> |
                     {{/if}}
                     <a href="">Reply</a>
                   </div>


### PR DESCRIPTION
This PR does three things:
1. Improves comment deletion by checking to make sure a user is an admin at the API level (Closes #17)
2. Fixes comment deletion because it was stupidly generating/using the same ID for multiple delete links, which doesn't work.
3. Fixes the same issue as 2, but with comment flagging. (Closes #28)