### PR TITLE
Clean up search results

### DIFF
--- a/templates/views/searchResults.hbs
+++ b/templates/views/searchResults.hbs
@@ -35,6 +35,14 @@
         {{/each}}
         </ul>
         {{/if}}
+	  
+        {{#unless tags}}
+	    {{#unless categories}}
+	      {{#unless posts}}
+              <h2>No results found</h2>
+	      {{/unless}}
+	    {{/unless}}
+        {{/unless}}
 
       </article>
       <!-- /CONTENT -->

--- a/templates/views/searchResults.hbs
+++ b/templates/views/searchResults.hbs
@@ -9,26 +9,32 @@
         </section>
         <!-- /TITLE BOX -->
 
+        {{#if tags}}
         <h2>Tags Matching "{{searchTerms}}"</h2>
         <ul>
         {{#each tags}}
           <li><a href="/tags/{{this.slug}}">{{this.name}}</a>
         {{/each}}
         </ul>
+        {{/if}}
 
+        {{#if categories}}
         <h2>Categories Matching "{{searchTerms}}"</h2>
         <ul>
         {{#each categories}}
           <li><a href="/categories/{{this.slug}}">{{this.name}}</a>
         {{/each}}
         </ul>
+        {{/if}}
 
+        {{#if posts}}
         <h2>Posts Matching "{{searchTerms}}"</h2>
         <ul>
         {{#each posts}}
           <li><a href="/{{toLowerCase this.postType}}s/{{this.slug}}">{{this.title}}</a></li>
         {{/each}}
         </ul>
+        {{/if}}
 
       </article>
       <!-- /CONTENT -->


### PR DESCRIPTION
I've never used handlebars, so I hope this works.

For example, search "test"
There are no matching tags or categories, so don't display those headings.

If you search "xyz", there are no results, so display "No results found" (feel free to change this text)