### PR TITLE
Stop Using HTML to Pass User ID

### DIFF
--- a/routes/api/pro.js
+++ b/routes/api/pro.js
@@ -21,15 +21,26 @@ exports.register = function(req, res) {
     }
   }
 
-  // Make sure emails are the same
-  User.model.findById(data.userID).exec(function(err, user) {
-    if(user.email != data.email) { return res.apiError('emails do not match', err) }
-
-    user.addStripeSubscription(data, function(err) {
-      if (err) { return res.apiError('error', err) };
-      res.apiResponse({
-        user: user
-      });
+  if(!req.user.id || req.user.id === '') {
+    res.apiResponse({
+      success: false
     });
-  });
+  }
+  else {
+    User.model.findById(req.user.id).exec(function(err, user) {
+      if(user) {
+        user.addStripeSubscription(data, function(err) {
+          if (err) { return res.apiError('error', err) };
+          res.apiResponse({
+            success: true
+          });
+        });
+      }
+      else {
+        res.apiResponse({
+          success: false
+        });
+      }
+    });
+  }
 }

--- a/routes/views/account/avatarUpload.js
+++ b/routes/views/account/avatarUpload.js
@@ -10,15 +10,9 @@ exports = module.exports = function (req, res) {
     return res.redirect('/account/log-in');
   }
 
-  // If the id in the form doesn't match the id of the logged in user, no dice
-  if(req.user.id != req.body.userID) {
-    req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #1' });
-    return res.redirect('/account/profile')
-  }
-
   // If there's no image submitted, give up
   if(!req.files.file) {
-    req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #2' });
+    req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #1' });
     return res.redirect('/account/profile')
   }
 
@@ -37,26 +31,32 @@ exports = module.exports = function (req, res) {
   }
 
   view.on('init', function(next) {
-    // Look up existing user
-    User.model.findOne().where('_id', locals.formData.userID).exec(function(err, user) {
-      if (err) {
-        console.log(err);
-        return next(err);
-      }
-      if (!user || user === null) {
-        req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #3' });
-        return res.redirect('/account/profile');
-      }
-      locals.foundUser = user;
-      next();
-    });
+    if(req.user.id === '' || !req.user.id) {
+      req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #2' });
+      return res.redirect('/account/profile')
+    }
+    else {
+      // Look up existing user
+      User.model.findOne().where('_id', req.user.id).exec(function(err, user) {
+        if (err) {
+          req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #3' });
+          return res.redirect('/account/profile');
+        }
+        if (!user || user === null) {
+          req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #4' });
+          return res.redirect('/account/profile');
+        }
+        locals.foundUser = user;
+        return next();
+      });
+    }
   });
 
   view.on('init', function(next) {
     // upload the image to Cloudinary and assign the new URL
     cloudinary.uploader.upload(req.files.file.path, function(result, err) {
       if (err) {
-        req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #4' });
+        req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #5' });
         return res.redirect('/account/profile');
       }
       else {
@@ -71,7 +71,7 @@ exports = module.exports = function (req, res) {
     locals.foundUser.userImage = locals.newUserImage;
     locals.foundUser.save(function(err) {
       if (err) {
-        req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #5' });
+        req.flash('error', { detail: 'Sorry, something went wrong while uploading your avatar. Please try again. Error #6' });
         res.redirect('/account/profile');
       }
       req.flash('success', { detail: 'Changes Made!' });

--- a/routes/views/account/cancelProSubscription.js
+++ b/routes/views/account/cancelProSubscription.js
@@ -11,12 +11,6 @@ exports = module.exports = function (req, res) {
     return res.redirect('/account/log-in');
   }
 
-  // If the id in the form doesn't match the id of the logged in user, no dice
-  if(req.user.id != req.body.userID) {
-    req.flash('error', { detail: 'Sorry, something went wrong while trying to cancel your subscription. Please try again. Error #1' });
-    return res.redirect('/account/profile');
-  }
-
   // If there's no cancel text, give up
   if(req.body.accountCancelSubscriptionConfirmText !== 'CANCEL SUBSCRIPTION') {
     req.flash('error', { detail: 'Incorrect text entered.' });

--- a/routes/views/account/editProfile.js
+++ b/routes/views/account/editProfile.js
@@ -9,12 +9,6 @@ exports = module.exports = function (req, res) {
     return res.redirect('/account/log-in');
   }
 
-  // If the id in the form doesn't match the id of the logged in user, no dice
-  if(req.user.id != req.body.userID) {
-    req.flash('error', { detail: 'Sorry, something went wrong while trying to update your profile. Please try again. Error #1' });
-    return res.redirect('/account/profile')
-  }
-
   var view = new keystone.View(req, res);
   var locals = res.locals;
   locals.section = 'account';
@@ -33,16 +27,16 @@ exports = module.exports = function (req, res) {
   locals.hideAds = true;
 
   view.on('init', function(next) {
-    // Look up existing user
-    User.model.findOne().where('_id', locals.formData.userID).exec(function(err, user) {
+    // Look up currently logged in user
+    User.model.findOne().where('_id', req.user.id).exec(function(err, user) {
       if (err) {
-        console.log(err);
         return next(err);
       }
       if (!user) {
         req.flash('error', { detail: 'Sorry, something went wrong while trying to update your profile. Please try again. Error #2' });
         return res.redirect('/account/profile');
       }
+
       locals.found = user;
       next();
     });
@@ -60,7 +54,7 @@ exports = module.exports = function (req, res) {
       if (!foundUser) {
         return next();
       }
-      if (foundUser.id != locals.formData.userID) {
+      if (foundUser.id != req.user.id) {
         locals.dupeUsername = true;
       }
       next();

--- a/routes/views/account/updateProSubscription.js
+++ b/routes/views/account/updateProSubscription.js
@@ -10,16 +10,10 @@ exports = module.exports = function (req, res) {
     return res.redirect('/account/log-in');
   }
 
-  // If the id in the form doesn't match the id of the logged in user, no dice
-  if(req.user.id != req.body.userID) {
-    req.flash('error', { detail: 'Sorry, something went wrong while trying to update your card. Please try again. Error #1' });
-    return res.redirect('/account/profile');
-  }
-
   // If there's no token, no dice
   if(!req.body.stripeToken) {
-    req.flash('error', { detail: 'Sorry, something went wrong while trying to update your card. Please try again. Error #2' });
-    return res.redirect('/acount/profile');
+    req.flash('error', { detail: 'Sorry, something went wrong while trying to update your card. Please try again. Error #1' });
+    return res.redirect('/account/profile');
   }
 
   var view = new keystone.View(req, res);
@@ -29,8 +23,6 @@ exports = module.exports = function (req, res) {
   locals.user = req.user;
 
   view.on('post', function(next) {
-    console.log(locals.user.stripeID);
-    console.log(locals.formData.stripeToken);
     stripe.customers.update(
       locals.user.stripeID,
       { source: locals.formData.stripeToken },
@@ -45,7 +37,7 @@ exports = module.exports = function (req, res) {
         locals.user.updateStripeCard(locals.formData, function(err) {
           // if (err) return next(err);
           if (err) {
-            req.flash('error', { detail: 'Sorry, something went wrong while trying to update your card. Please try again. Error #3' });
+            req.flash('error', { detail: 'Sorry, something went wrong while trying to update your card. Please try again. Error #2' });
             next();
           }
           else {

--- a/templates/views/account/profile.hbs
+++ b/templates/views/account/profile.hbs
@@ -25,7 +25,6 @@
             <a href="#" class="image-upload" id="linkChangeImage">change</a>
             <form method="post" action="/account/avatar-upload" class="dropzone" id="avatar-upload" enctype="multipart/form-data">
               <input type="hidden" name="action" value="avatar-upload" />
-              <input type="hidden" name="userID" value="{{user.id}}" />
               <div class="fallback">
                 <label>Image File:<br/ ><input name="file" type="file" /></label>
               </div>
@@ -34,7 +33,6 @@
           <div class="info">
             <form method="post" action="/account/edit-profile" id="formEditProfile">
               <input type="hidden" name="action" value="edit-profile" />
-              <input type="hidden" name="userID" value="{{user._id}}" />
               <fieldset class="no-center">
 
                 <h4>Name</h4>
@@ -155,7 +153,6 @@
           <form id="formDeleteAccount" method="post" action="/account/delete-account">
             <fieldset>
               <input type="hidden" name="action" value="delete-account" />
-              <input type="hidden" name="userID" value="{{user.id}}" />
               <input type="text" name="accountDeleteConfirmText" />
             </fieldset>
             <div class="buttons">
@@ -189,7 +186,6 @@
               </p>
 
               <form action="/account/update-pro-subscription" method="post" id="cardUpdateForm">
-                <input type="hidden" name="userID" value="{{user.id}}" />
                 <div class="form-row">
                   <fieldset>
                     <label for="card-element">
@@ -270,7 +266,6 @@
               <form id="formCancelSubscription" method="post" action="/account/cancel-pro-subscription">
                 <fieldset>
                   <input type="hidden" name="action" value="cancel-subscription" />
-                  <input type="hidden" name="userID" value="{{user.id}}" />
                   <input type="text" name="accountCancelSubscriptionConfirmText" />
                 </fieldset>
                 <div class="buttons">

--- a/templates/views/goPro.hbs
+++ b/templates/views/goPro.hbs
@@ -241,8 +241,6 @@
               </div>
             </div>
             <!-- /SELECT BOXES -->
-            <input type="hidden" id="userID" value="{{user.id}}" />
-            <input type="hidden" id="userEmail" value="{{user.email}}" />
             <input type="hidden" id="proPlan" value="" />
             <div class="center"><button href="#" class="btn btn-primary btn-checkout">Check Out</button></div>
 

--- a/templates/views/partials/comments.hbs
+++ b/templates/views/partials/comments.hbs
@@ -21,7 +21,6 @@
                 <div class="text">
                   <!-- submission handled via ajax -->
                   <fieldset>
-                    <input type="hidden" id="hidUserID" value="{{user._id}}" />
                     <input type="hidden" id="hidPostID" value="{{post._id}}" />
                     <textarea name="comment" id="textAddComment"></textarea>
                   </fieldset>
@@ -80,11 +79,11 @@
                   -->
                   <div class="links">
                     {{#if ../user.isAdmin}}
-                      <a href="#" class="link-delete-comment" data-commentID="{{this.id}}" data-userID="{{../user.id}}">Admin Delete</a> |
+                      <a href="#" class="link-delete-comment" data-commentID="{{this.id}}">Admin Delete</a> |
                     {{/if}}
                     {{#ifeq ../user.id this.author.id}}
                       {{#unless this.isUserDeleted}}
-                      <a href="#" class="link-delete-comment-user" data-userID={{../user.id}} data-commentID="{{this.id}}">Delete</a> |
+                      <a href="#" class="link-delete-comment-user" data-commentID="{{this.id}}">Delete</a> |
                       {{/unless}}
                     {{else}}
                       <a href="#" class="flag link-flag-comment" data-flagger="{{../user.id}}" data-commentID="{{this.id}}">Flag</a> |


### PR DESCRIPTION
Closes #46 by exclusively using req.user.id instead of passing things around with hidden fields. A User's ID should no longer be exposed in the HTML at any point.